### PR TITLE
Returning filename and filepath in ExportStats

### DIFF
--- a/tcstore-exporter/src/main/java/org/terracotta/store/export/ParquetExportStats.java
+++ b/tcstore-exporter/src/main/java/org/terracotta/store/export/ParquetExportStats.java
@@ -22,6 +22,7 @@ import com.terracottatech.store.definition.CellDefinition;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -38,6 +39,8 @@ public class ParquetExportStats
     private long stringsTruncated;
     private long arraysNullified;
     private Map<CellDefinition<?>, Integer> schemaAbsentCellNoWriteCounts = new HashMap<>();
+    private List<String> filenames;
+    private List<String> filenamePaths;
 
     /**
      * @return the number of records that were completely written (all of the cells were accounted for in the output
@@ -131,5 +134,27 @@ public class ParquetExportStats
 
     protected void setExportSuccess(boolean exportStatus) {
         this.exportSuccess = exportStatus;
+    }
+
+    /**
+     * @return the name(s) of the generated parquet file(s).
+     */
+    public List<String> getFilenames() {
+        return filenames;
+    }
+
+    public void setFilenames(List<String> filenames) {
+        this.filenames = filenames;
+    }
+
+    /**
+     * @return the full path names of the generated parquet file(s).
+     */
+    public List<String> getFilenamePaths() {
+        return filenamePaths;
+    }
+
+    public void setFilenamePaths(List<String> filenamePaths) {
+        this.filenamePaths = filenamePaths;
     }
 }

--- a/tcstore-exporter/src/main/java/org/terracotta/store/export/ParquetExportStats.java
+++ b/tcstore-exporter/src/main/java/org/terracotta/store/export/ParquetExportStats.java
@@ -143,7 +143,7 @@ public class ParquetExportStats
         return filenames;
     }
 
-    public void setFilenames(List<String> filenames) {
+    protected void setFilenames(List<String> filenames) {
         this.filenames = filenames;
     }
 
@@ -154,7 +154,7 @@ public class ParquetExportStats
         return filenamePaths;
     }
 
-    public void setFilenamePaths(List<String> filenamePaths) {
+    protected void setFilenamePaths(List<String> filenamePaths) {
         this.filenamePaths = filenamePaths;
     }
 }


### PR DESCRIPTION
- return generated filename(s) and filepath(s) in ParquetExportStats.
- included code-snippets for handling new CDT types in 10.7 (work in progress - mostly commented out for now).