### PR TITLE
'Supporting' 10.7 by ignoring CDT cells

### DIFF
--- a/tcstore-exporter/src/main/java/org/terracotta/store/export/CmdLineOptions.java
+++ b/tcstore-exporter/src/main/java/org/terracotta/store/export/CmdLineOptions.java
@@ -345,7 +345,7 @@ public class CmdLineOptions
             if (filterCellName.isEmpty())
                 validationErrors.append("Filter Cell Name (" + FILTER_CELL_NAME + ") value not specified\n");
 
-            Type type = getType(filterCellType);
+            Type<?> type = getType(filterCellType);
             if (type == null)
                 validationErrors.append("Filter Cell Type (" + FILTER_CELL_TYPE + ") value not specified or is invalid\n");
             else {
@@ -372,7 +372,7 @@ public class CmdLineOptions
                     validationErrors.append("Blank cell name found in Exportable Cell List (" + EXPORTABLE_CELLS + ")\n");
                 if (++i < count) {
                     String cellType = whiteListCellsNamesTypes.get(i).trim();
-                    Type type = getType(cellType);
+                    Type<?> type = getType(cellType);
                     if (type == null)
                         validationErrors.append("Exportable Cell Type (" + EXPORTABLE_CELLS + ") '" + cellType + "' not specified or is invalid\n");
                 }
@@ -391,7 +391,7 @@ public class CmdLineOptions
                     validationErrors.append("Blank cell name found in Non-Exportable Cell List (" + EXPORTABLE_CELLS + ")\n");
                 if (++i < count) {
                     String cellType = blackListCellsNamesTypes.get(i).trim();
-                    Type type = getType(cellType);
+                    Type<?> type = getType(cellType);
                     if (type == null)
                         validationErrors.append("Non-Exportable Cell Type (" + NONEXPORTABLE_CELLS + ") '" + cellType + "' not specified or is invalid\n");
                 }

--- a/tcstore-exporter/src/main/java/org/terracotta/store/export/ExportToParquetCmd.java
+++ b/tcstore-exporter/src/main/java/org/terracotta/store/export/ExportToParquetCmd.java
@@ -49,7 +49,7 @@ public class ExportToParquetCmd
 
             String uri = cmd.getServerUri();
             String datasetName = cmd.getDatasetName();
-            Type datasetType = cmd.getType(cmd.getDatasetType());
+            Type<?> datasetType = cmd.getType(cmd.getDatasetType());
             String outputFileFolder = cmd.getOutput();
 
             ParquetOptions options = new ParquetOptions();


### PR DESCRIPTION
Temporary 'support' for 10.7 CDTs by intentionally filtering out list and map cells (until we formally support them by including their data in the exported parquet).