### PR TITLE
Added schema construction predicate option

### DIFF
--- a/tcstore-exporter/src/main/java/org/terracotta/store/export/ParquetExportStats.java
+++ b/tcstore-exporter/src/main/java/org/terracotta/store/export/ParquetExportStats.java
@@ -34,6 +34,7 @@ public class ParquetExportStats
     private boolean exportSuccess = false;
     private long fullRecordWrites;
     private long partialRecordWrites;
+    private long entireRecordsNotWritten;
     private long failedRecordWrites;
     private long recordsProcessed;
     private long stringsTruncated;
@@ -67,7 +68,17 @@ public class ParquetExportStats
     }
 
     /**
-     * @return the number of records that were not written to the output file due to error
+     * @return the number of records that were entirely not written to the output file (all of the cells were NOT accounted for in the output
+     * schema)
+     */
+    public long getEntireRecordsNotWritten() {
+        return entireRecordsNotWritten;
+    }
+
+    protected void setEntireRecordsNotWritten(long entireRecordsNotWritten) { this.entireRecordsNotWritten = entireRecordsNotWritten; }
+
+    /**
+     * @return the number of records that were not written to the output file due to an error
      */
     public long getFailedRecordWrites() {
         return failedRecordWrites;

--- a/tcstore-exporter/src/main/java/org/terracotta/store/export/ParquetOptions.java
+++ b/tcstore-exporter/src/main/java/org/terracotta/store/export/ParquetOptions.java
@@ -17,6 +17,7 @@
  */
 package org.terracotta.store.export;
 
+import com.terracottatech.store.Record;
 import com.terracottatech.store.Type;
 import com.terracottatech.store.definition.CellDefinition;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
@@ -25,6 +26,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.function.Predicate;
 
 /**
  * Options for the export of Dataset contents to a parquet file.
@@ -69,6 +71,7 @@ public class ParquetOptions {
     private Set<CellDefinition<?>> blackListCells = new HashSet<>();
     private Integer maxStringLength = -1;
     private Integer maxByteArraySize = -1;
+    private Predicate<Record<?>> schemaSampleFilter;
 
     /**
      * Add a cell to the "whitelist" of cells that should be included in the output
@@ -272,6 +275,17 @@ public class ParquetOptions {
      */
     public void setMaxByteArraySize(Integer maxByteArraySize) {
         this.maxByteArraySize = maxByteArraySize;
+    }
+
+    public Predicate<Record<?>> getSchemaSampleFilter() {
+        return schemaSampleFilter;
+    }
+
+    /**
+     * @param schemaSampleFilter construct the parquet schema based on cells contained in records that match the supplied predicate
+     */
+    public void setSchemaSampleFilter(Predicate<Record<?>> schemaSampleFilter) {
+        this.schemaSampleFilter = schemaSampleFilter;
     }
 }
 

--- a/tcstore-exporter/src/main/java/org/terracotta/store/export/ParquetSchema.java
+++ b/tcstore-exporter/src/main/java/org/terracotta/store/export/ParquetSchema.java
@@ -29,6 +29,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.*;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static java.util.Objects.requireNonNull;
@@ -83,7 +84,12 @@ public class ParquetSchema {
         try (Dataset<?> dataset = dsManager.getDataset(this.datasetName, this.datasetType)) {
             Set<CellDefinition<?>> uniqueCells;
             try (RecordStream<?> records = dataset.reader().records()) {
-                uniqueCells = records
+                RecordStream<?> working = records;
+                Predicate<Record<?>> schemaSampleFilter = options.getSchemaSampleFilter();
+                if (schemaSampleFilter != null) {
+                    working = working.filter(schemaSampleFilter);
+                }
+                uniqueCells = working
                     .limit(options.getSchemaSampleSize())
                     .flatMap(Record::stream)
                     .map(Cell::definition)

--- a/tcstore-exporter/src/test/java/org/terracotta/store/export/DatasetParquetFileExporterTest.java
+++ b/tcstore-exporter/src/test/java/org/terracotta/store/export/DatasetParquetFileExporterTest.java
@@ -19,7 +19,7 @@ package org.terracotta.store.export;
 
 import com.terracottatech.store.Record;
 import com.terracottatech.store.Type;
-import com.terracottatech.store.definition.CellDefinition;
+import com.terracottatech.store.definition.*;
 import com.terracottatech.store.manager.DatasetManager;
 import org.junit.Test;
 
@@ -44,15 +44,15 @@ public class DatasetParquetFileExporterTest {
                 "-t", "LONG",
                 "-o", "C:\\temp",
 
-                "-ss", "10",
+                "-ss", "1",
                 "-a",
-                "-fn", "C0001",
-                "-ft", "LONG",
-                "-flv", "1",
-                "-fhv", "10",
-                "-ia",
+                //"-fn", "C0001",
+                //"-ft", "LONG",
+                //"-flv", "1",
+                //"-fhv", "10",
+                //"-ia",
 
-                //"-mc", "4",
+                //"-mc", "9",
                 //"-mcia",
                 //"-mcmf",
 
@@ -95,7 +95,7 @@ public class DatasetParquetFileExporterTest {
     {
         String uri = "terracotta://localhost:9410";
         String datasetName = "DS1";
-        Type datasetType = Type.LONG;
+        Type<?> datasetType = Type.LONG;
         String outputFileFolder = "C:\\temp";
 
         ParquetOptions options = new ParquetOptions();
@@ -151,7 +151,7 @@ public class DatasetParquetFileExporterTest {
     {
         String uri = "terracotta://localhost:9410";
         String datasetName = "DS1";
-        Type datasetType = Type.LONG;
+        Type<?> datasetType = Type.LONG;
         String outputFileFolder = "C:\\temp";
 
         ParquetOptions options = new ParquetOptions();
@@ -161,6 +161,38 @@ public class DatasetParquetFileExporterTest {
             // custom filter example (e.g. only write records with even numbered keys)
             Predicate<Record<?>> filter = (r -> (((Long)r.getKey()) % 2) == 0); //DS1 dataset is type long
             exporter.exportDataset(filter);
+        }
+        catch (Exception ex)
+        {
+        }
+    }
+
+    @Test
+    public void Api_Schema_Filter_Test()
+    {
+        String uri = "terracotta://localhost:9410";
+        String datasetName = "DS1";
+        Type<?> datasetType = Type.LONG;
+        String outputFileFolder = "C:\\temp";
+
+        ParquetOptions options = new ParquetOptions();
+
+        // Schema-Sampling Filter Examples
+
+        //BoolCellDefinition cell = CellDefinition.defineBool("C0010");
+        //options.setSchemaSampleFilter(cell.value().is(true));
+
+        //LongCellDefinition cell = CellDefinition.defineLong("C0001");
+        //options.setSchemaSampleFilter(cell.value().isGreaterThanOrEqualTo(400L));
+
+        LongCellDefinition c1 = CellDefinition.defineLong("C0001");
+        BoolCellDefinition c2 = CellDefinition.defineBool("C0020");
+        StringCellDefinition c3 = CellDefinition.defineString("C0015");
+        options.setSchemaSampleFilter(c1.exists().and(c2.exists().and(c3.exists())));
+
+        try (DatasetManager dsManager = DatasetManager.clustered((new URI(uri))).build()) {
+            DatasetParquetFileExporter exporter = new DatasetParquetFileExporter(dsManager, datasetName, datasetType, outputFileFolder, options);
+            exporter.exportDataset();
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
- added option to construct schema based on supplied predicate to ParquetOptions
- added test method with example predicate
- added count of records that were entirely not exported to ParquetExportStats.